### PR TITLE
Adds support to IoCtx for querying for pool alignment 

### DIFF
--- a/cradox.pyx.in
+++ b/cradox.pyx.in
@@ -3759,11 +3759,11 @@ returned %d, but should return zero on success." % (self.name, ret))
 
     def alignment(self):
         """
-        Returns required alignment required for EC writes
+        Returns pool alignment 
 
         :returns: 
-            The number of bytes for alignment is required by the current pool,
-            -1 otherwise.
+            Number of alignment bytes required by the current pool, or -1 if 
+            alignment is not required.
         """
         cdef:
             int requires = 0 

--- a/cradox.pyx.in
+++ b/cradox.pyx.in
@@ -228,6 +228,9 @@ cdef extern from "rados/librados.h" nogil:
     int rados_nobjects_list_next(rados_list_ctx_t ctx, const char **entry, const char **key, const char **nspace)
     void rados_nobjects_list_close(rados_list_ctx_t ctx)
 
+    int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int * requires)
+    int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t * alignment)
+
     int rados_ioctx_snap_rollback(rados_ioctx_t io, const char * oid, const char * snapname)
     int rados_ioctx_snap_create(rados_ioctx_t io, const char * snapname)
     int rados_ioctx_snap_remove(rados_ioctx_t io, const char * snapname)
@@ -3754,6 +3757,32 @@ returned %d, but should return zero on success." % (self.name, ret))
             free(c_vals)
 {% endif %}
 
+    def alignment(self):
+        """
+        Returns required alignment required for EC writes
+
+        :returns: 
+            The number of bytes for alignment is required by the current pool,
+            -1 otherwise.
+        """
+        cdef:
+            int requires = 0 
+            uint64_t _alignment
+            
+        with nogil:
+            ret = rados_ioctx_pool_requires_alignment2(self.io, &requires)
+        if ret != 0:
+            raise make_ex(ret, "error checking alignment")
+
+        alignment = None
+        if requires:
+            with nogil:
+                ret = rados_ioctx_pool_required_alignment2(self.io, &_alignment)
+            if ret != 0:
+                raise make_ex(ret, "error querying alignment")
+            alignment = _alignment
+        return alignment 
+    
 
 def set_object_locator(func):
     def retfunc(self, *args, **kwargs):

--- a/test_rados.py.in
+++ b/test_rados.py.in
@@ -894,6 +894,36 @@ class TestIoctx(object):
         eq([("key2", "val2")], self.ioctx.application_metadata_list("app1"))
 {% endif %}
 
+    def test_alignment(self):
+        eq(self.ioctx.alignment(), None)
+
+class TestIoctxEc(object):
+
+    def setUp(self):
+        self.rados = Rados(conffile='')
+        self.rados.connect()
+        # create ec pool with profile created above
+        import subprocess
+        subprocess.call("ceph osd pool create test_pool_ec 16 erasure default", 
+                        shell=True)
+        # I'm not sure why what's below does not work
+        # cmd = {'prefix': 'osd pool create', 'pg_num': 16, 
+        #        'pool': 'test_pool_ec', 'erasure_code_profile': 'default'}
+        # ret, buf, out = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
+        # eq(ret, 0, msg=out)
+        assert self.rados.pool_exists('test_pool_ec')
+        self.ioctx = self.rados.open_ioctx('test_pool_ec')
+
+    def tearDown(self):
+        cmd = {"prefix":"osd unset", "key":"noup"}
+        self.rados.mon_command(json.dumps(cmd), b'')
+        self.ioctx.close()
+        self.rados.delete_pool('test_pool_ec')
+        self.rados.shutdown()
+    
+    def test_alignment(self):
+        eq(self.ioctx.alignment(), 4096)
+
 class TestObject(object):
 
     def setUp(self):


### PR DESCRIPTION
There are certain pool configurations, namely EC pool configurations, require the IO size to be a multiple of the alignment if you are writing an object using multiple writes. This pull request adds a single method to `IoCtx` for querying the number of alignment bytes.
