### PR TITLE
Pin Cython version less than 0.28.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def setup_hook(cmd_obj, version=None):
 if __name__ == '__main__':
     setup(
         # cradox segfault with 0.28.0
-        setup_requires=['pbr', 'Cython!=0.28.0,!=0.28.1,!=0.28.2', 'Jinja2'],
+        setup_requires=['pbr', 'Cython<0.28.0', 'Jinja2'],
         pbr=True,
         ext_modules=[Extension("cradox", ["cradox.pyx"], libraries=["rados"])],
     )


### PR DESCRIPTION
cradox doesn't work with Cython 0.28.0. Cython 0.28.3 is release
yesterday, and it breaks gnocchi again. So pin Cython to version less
than 0.28.0 until cradox and Cython could really work together.